### PR TITLE
Fix sequence generation to be always increasing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,7 +478,7 @@ mod tests {
     #[test]
     fn test_components() {
         let mut components = Components::new(0);
-        assert_eq!(components.sequence(), 0);
+        assert_eq!(components.sequence(), 1);
         assert_eq!(components.timestamp(), 0);
 
         components.set_sequence(1024);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ impl Components {
     }
 
     pub(crate) fn reset_sequence(&mut self) {
-        self.set_sequence(4095)
+        self.set_sequence(1)
     }
 
     pub(crate) fn set_timestamp(&mut self, ts: u64) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,6 @@ impl Generator {
     {
         use std::cmp::Ordering;
 
-        let sequence;
         let mut now = self.epoch.elapsed().unwrap().as_millis() as u64;
         let instance = self.components.instance();
         match now.cmp(&self.components.timestamp()) {
@@ -363,7 +362,7 @@ impl Generator {
                 T::from_parts(now, instance, 0)
             },
             Ordering::Equal => {
-                sequence = self.components.take_sequence();
+                let sequence = self.components.take_sequence();
                 if sequence == 0 {
                     now = self.wait_until_next_millisecond(now);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,8 @@ pub(crate) struct Components(u64);
 impl Components {
     #[inline]
     pub(crate) const fn new(instance: u64) -> Self {
-        Self((instance << 12) & BITMASK_INSTANCE)
+        // Fill in the given instance, and set the sequence at '1'
+        Self((instance << 12) & BITMASK_INSTANCE | 1)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,24 +348,39 @@ impl Generator {
     where
         T: Snowflake,
     {
-        let sequence = self.components.take_sequence();
+        use std::cmp::Ordering;
 
-        let timestamp;
+        let sequence;
+        let mut now = self.epoch.elapsed().unwrap().as_millis() as u64;
+        let instance = self.components.instance();
+        match now.cmp(&self.components.timestamp()) {
+            Ordering::Less => {
+                panic!("Clock has moved backwards! This is not supported.");
+            },
+            Ordering::Greater => {
+                self.components.reset_sequence();
+                self.components.set_timestamp(now);
+                T::from_parts(now, instance, 0)
+            },
+            Ordering::Equal => {
+                sequence = self.components.take_sequence();
+                if sequence == 0 {
+                    now = self.wait_until_next_millisecond(now);
+                }
+                self.components.set_timestamp(now);
+                T::from_parts(now, instance, sequence)
+            }
+        }
+    }
+
+    fn wait_until_next_millisecond(&mut self, last_millisecond: u64) -> u64 {
         loop {
             let now = self.epoch.elapsed().unwrap().as_millis() as u64;
-
-            if sequence != 4095 || now > self.components.timestamp() {
-                self.components.set_timestamp(now);
-                timestamp = now;
-                break;
+            if now > last_millisecond {
+                return now;
             }
-
             std::hint::spin_loop();
         }
-
-        let instance = self.components.instance();
-
-        T::from_parts(timestamp, instance, sequence)
     }
 }
 
@@ -408,6 +423,10 @@ impl Components {
         let timestamp = self.timestamp() << 22;
         let instance = (self.instance() << 12) & BITMASK_INSTANCE;
         *self = Self(timestamp + instance + seq)
+    }
+
+    pub(crate) fn reset_sequence(&mut self) {
+        self.set_sequence(4095)
     }
 
     pub(crate) fn set_timestamp(&mut self, ts: u64) {
@@ -477,21 +496,17 @@ mod tests {
     }
 
     #[test]
-    fn test_generate() {
+    fn test_generate_ordered() {
         const INSTANCE: u64 = 0;
 
-        let mut sequence = 0;
+        let mut last_id = None;
         let mut generator = Generator::new_unchecked(INSTANCE as u16);
 
         for _ in 0..10_000 {
             let id: u64 = generator.generate();
             assert_eq!(id.instance(), INSTANCE);
-            assert_eq!(id.sequence(), sequence);
-
-            match sequence {
-                4095 => sequence = 0,
-                _ => sequence += 1,
-            }
+            assert!(last_id < Some(id), "expected {:?} to be less than {:?}", last_id, Some(id));
+            last_id = Some(id);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,12 +355,12 @@ impl Generator {
         match now.cmp(&self.components.timestamp()) {
             Ordering::Less => {
                 panic!("Clock has moved backwards! This is not supported.");
-            },
+            }
             Ordering::Greater => {
                 self.components.reset_sequence();
                 self.components.set_timestamp(now);
                 T::from_parts(now, instance, 0)
-            },
+            }
             Ordering::Equal => {
                 let sequence = self.components.take_sequence();
                 if sequence == 0 {
@@ -504,7 +504,12 @@ mod tests {
         for _ in 0..10_000 {
             let id: u64 = generator.generate();
             assert_eq!(id.instance(), INSTANCE);
-            assert!(last_id < Some(id), "expected {:?} to be less than {:?}", last_id, Some(id));
+            assert!(
+                last_id < Some(id),
+                "expected {:?} to be less than {:?}",
+                last_id,
+                Some(id)
+            );
             last_id = Some(id);
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -272,7 +272,10 @@ where
         F: Fn(),
     {
         loop {
-            println!("Waiting until the next millisecond from {}", last_millisecond);
+            println!(
+                "Waiting until the next millisecond from {}",
+                last_millisecond
+            );
             let now = epoch.elapsed().as_millis() as u64;
             if now > last_millisecond {
                 return now;
@@ -430,18 +433,17 @@ mod loom_tests {
             let generator = Arc::new(InternalGenerator::<TestTime>::new_unchecked(0));
             let (tx, rx) = mpsc::channel();
 
-            let threads: Vec<_> =
-                (0..THREADS)
-                    .map(|_| {
-                        let generator = generator.clone();
-                        let tx = tx.clone();
+            let threads: Vec<_> = (0..THREADS)
+                .map(|_| {
+                    let generator = generator.clone();
+                    let tx = tx.clone();
 
-                        thread::spawn(move || {
-                            let id: u64 = generator.generate(panic_on_wait);
-                            tx.send(id).unwrap();
-                        })
+                    thread::spawn(move || {
+                        let id: u64 = generator.generate(panic_on_wait);
+                        tx.send(id).unwrap();
                     })
-                    .collect();
+                })
+                .collect();
 
             for th in threads {
                 th.join().unwrap();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -271,10 +271,6 @@ where
         F: Fn(),
     {
         loop {
-            println!(
-                "Waiting until the next millisecond from {}",
-                last_millisecond
-            );
             let now = epoch.elapsed().as_millis() as u64;
             if now > last_millisecond {
                 return now;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -245,13 +245,13 @@ where
                 match now.cmp(&components.timestamp()) {
                     cmp::Ordering::Less => {
                         panic!("Clock has moved backwards! This is not supported");
-                    },
+                    }
                     cmp::Ordering::Greater => {
                         components.reset_sequence();
                         components.set_timestamp(now);
                         id = Some(S::from_parts(now, instance, 0));
                         Some(components.to_bits())
-                    },
+                    }
                     cmp::Ordering::Equal => {
                         let sequence = components.take_sequence();
                         if sequence == 0 {
@@ -266,7 +266,7 @@ where
         id.expect("ID should have been set within the fetch_update closure.")
     }
 
-    fn wait_until_next_millisecond<F>(epoch: &T, last_millisecond: u64, tick_wait: F) -> u64 
+    fn wait_until_next_millisecond<F>(epoch: &T, last_millisecond: u64, tick_wait: F) -> u64
     where
         F: Fn(),
     {
@@ -298,7 +298,12 @@ mod tests {
         for _ in 0..10_000 {
             let id: u64 = generator.generate();
             assert_eq!(id.instance(), INSTANCE);
-            assert!(last_id < Some(id), "expected {:?} to be less than {:?}", last_id, Some(id));
+            assert!(
+                last_id < Some(id),
+                "expected {:?} to be less than {:?}",
+                last_id,
+                Some(id)
+            );
             last_id = Some(id);
         }
     }
@@ -423,17 +428,18 @@ mod loom_tests {
             let generator = Arc::new(InternalGenerator::<TestTime>::new_unchecked(0));
             let (tx, rx) = mpsc::channel();
 
-            let threads: Vec<_> = (0..THREADS)
-                .map(|_| {
-                    let generator = generator.clone();
-                    let tx = tx.clone();
+            let threads: Vec<_> =
+                (0..THREADS)
+                    .map(|_| {
+                        let generator = generator.clone();
+                        let tx = tx.clone();
 
-                    thread::spawn(move || {
-                        let id: u64 = generator.generate(panic_on_wait);
-                        tx.send(id).unwrap();
+                        thread::spawn(move || {
+                            let id: u64 = generator.generate(panic_on_wait);
+                            tx.send(id).unwrap();
+                        })
                     })
-                })
-                .collect();
+                    .collect();
 
             for th in threads {
                 th.join().unwrap();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -254,7 +254,6 @@ where
                     }
                     cmp::Ordering::Equal => {
                         let sequence = components.take_sequence();
-                        dbg!((now, instance, sequence));
                         if sequence == 0 {
                             now = Self::wait_until_next_millisecond(&self.epoch, now, &tick_wait);
                         }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -146,7 +146,7 @@ impl Generator {
     where
         T: Snowflake,
     {
-        self.internal.generate(&std::hint::spin_loop)
+        self.internal.generate(std::hint::spin_loop)
     }
 }
 
@@ -223,7 +223,7 @@ where
         self.epoch
     }
 
-    fn generate<S, F>(&self, tick_wait: &F) -> S
+    fn generate<S, F>(&self, tick_wait: F) -> S
     where
         S: Snowflake,
         F: Fn(),
@@ -255,7 +255,7 @@ where
                     cmp::Ordering::Equal => {
                         let sequence = components.take_sequence();
                         if sequence == 0 {
-                            now = Self::wait_until_next_millisecond(&self.epoch, now, tick_wait);
+                            now = Self::wait_until_next_millisecond(&self.epoch, now, &tick_wait);
                         }
                         components.set_timestamp(now);
                         id = Some(S::from_parts(now, instance, sequence));

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -254,6 +254,7 @@ where
                     }
                     cmp::Ordering::Equal => {
                         let sequence = components.take_sequence();
+                        dbg!((now, instance, sequence));
                         if sequence == 0 {
                             now = Self::wait_until_next_millisecond(&self.epoch, now, &tick_wait);
                         }
@@ -271,6 +272,7 @@ where
         F: Fn(),
     {
         loop {
+            println!("Waiting until the next millisecond from {}", last_millisecond);
             let now = epoch.elapsed().as_millis() as u64;
             if now > last_millisecond {
                 return now;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -14,7 +14,6 @@
 //! }
 //! ```
 
-use std::mem::MaybeUninit;
 use std::time::SystemTime;
 
 use crate::builder::Builder;
@@ -147,7 +146,7 @@ impl Generator {
     where
         T: Snowflake,
     {
-        self.internal.generate(std::hint::spin_loop)
+        self.internal.generate(&std::hint::spin_loop)
     }
 }
 
@@ -224,46 +223,60 @@ where
         self.epoch
     }
 
-    fn generate<S, F>(&self, tick_wait: F) -> S
+    fn generate<S, F>(&self, tick_wait: &F) -> S
     where
         S: Snowflake,
         F: Fn(),
     {
-        // Even thought we only assign this value once we need to assign this value to
-        // something before passing it (reference) into the closure.
-        // This value is safe to read after the closure completes.
-        let mut id = MaybeUninit::uninit();
+        use std::cmp;
+
+        // Since `fetch_update` doesn't return a result,
+        // we store the result in this mutable variable.
+        // Note that using MaybeUninit is not necessary
+        // as the compiler is smart enough to elide the Option for us.
+        let mut id = None;
 
         let _ = self
             .components
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |bits| {
                 let mut components = Components::from_bits(bits);
-
-                let sequence = components.take_sequence();
-
-                let timestamp;
-                loop {
-                    let now = self.epoch.elapsed().as_millis() as u64;
-
-                    if sequence != 4095 || now > components.timestamp() {
-                        components.set_timestamp(now);
-                        timestamp = now;
-                        break;
-                    }
-
-                    tick_wait();
-                }
-
+                let mut now = self.epoch.elapsed().as_millis() as u64;
                 let instance = components.instance();
-
-                id.write(S::from_parts(timestamp, instance, sequence));
-
-                Some(components.to_bits())
+                match now.cmp(&components.timestamp()) {
+                    cmp::Ordering::Less => {
+                        panic!("Clock has moved backwards! This is not supported");
+                    },
+                    cmp::Ordering::Greater => {
+                        components.reset_sequence();
+                        components.set_timestamp(now);
+                        id = Some(S::from_parts(now, instance, 0));
+                        Some(components.to_bits())
+                    },
+                    cmp::Ordering::Equal => {
+                        let sequence = components.take_sequence();
+                        if sequence == 0 {
+                            now = Self::wait_until_next_millisecond(&self.epoch, now, tick_wait);
+                        }
+                        components.set_timestamp(now);
+                        id = Some(S::from_parts(now, instance, sequence));
+                        Some(components.to_bits())
+                    }
+                }
             });
+        id.expect("ID should have been set within the fetch_update closure.")
+    }
 
-        // SAFETY: The call to `fetch_update` only completes once the closure ran fully.
-        // At this point `id` has been initialized from within the closure.
-        unsafe { id.assume_init() }
+    fn wait_until_next_millisecond<F>(epoch: &T, last_millisecond: u64, tick_wait: F) -> u64 
+    where
+        F: Fn(),
+    {
+        loop {
+            let now = epoch.elapsed().as_millis() as u64;
+            if now > last_millisecond {
+                return now;
+            }
+            tick_wait();
+        }
     }
 }
 
@@ -279,18 +292,14 @@ mod tests {
     fn test_generate() {
         const INSTANCE: u64 = 0;
 
-        let mut sequence = 0;
+        let mut last_id = None;
         let generator = Generator::new_unchecked(INSTANCE as u16);
 
         for _ in 0..10_000 {
             let id: u64 = generator.generate();
             assert_eq!(id.instance(), INSTANCE);
-            assert_eq!(id.sequence(), sequence);
-
-            match sequence {
-                4095 => sequence = 0,
-                _ => sequence += 1,
-            }
+            assert!(last_id < Some(id), "expected {:?} to be less than {:?}", last_id, Some(id));
+            last_id = Some(id);
         }
     }
 


### PR DESCRIPTION
- [x] Fixes generation of the normal generator
- [x] Fixes generation of the sync generator
- [x] Replaces the two incorrect `test_generate` tests with `test_generate_ordered` tests
- [x] Gets rid of `MaybeUninit` inside the sync generation. I've looked at the created assembly (using [cargo asm](https://github.com/gnzlbg/cargo-asm)) and the compiler is more than clever enough to optimize the wrapping and unwrapping into an `Option` away here, so there's no need for unsafe. (Extra fun as it was the only unsafe in this crate, so now it's fully `no-unsafe`!)


Fixes #5 